### PR TITLE
Turned redirection into linked list.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,19 @@
 # **************************************************************************** #
 #                                                                              #
 #                                                         ::::::::             #
-#    Makefile                                           :+:    :+:             #
+#    Makefile                                           :+:      :+:    :+:    #
 #                                                      +:+                     #
 #    By: nakanoun <nakanoun@student.codam.nl>         +#+                      #
 #                                                    +#+                       #
 #    Created: 2023/04/25 13:56:08 by nakanoun      #+#    #+#                  #
-#    Updated: 2023/04/25 13:56:08 by nakanoun      ########   odam.nl          #
+#    Updated: 2023/05/16 22:40:49 by ysrondy          ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
 NAME := minishell
 
 # CFLAGS := -Wall -Wextra -Werror #-g -fsanitize=address
-CFLAGS := -g -fsanitize=address
+# CFLAGS := -g -fsanitize=address
 
 #Lib
 LIB_LIBFT = ./lib/libft/libft.a

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -46,7 +46,7 @@ typedef enum s_lst_type
 	CMDS_LIST = 2,
 }	t_lst_type;
 
-/* 
+/*
 	stuct for envp_list key,value
  */
 typedef struct s_env
@@ -126,7 +126,7 @@ void	expander(t_token **lst_tokens, t_tools *tools);
 char	*expand_arg(char *string, t_tools *tools);
 
 				/* Printing (DEBUGGING) */
-void	print_token_list(t_token **lst_head);
+void	print_token_list(t_token **lst_head, int print_redirection);
 void	print_cmds_list(t_commands **lst_head);
 void	print_2d_array(char **arr);
 

--- a/src/main.c
+++ b/src/main.c
@@ -63,19 +63,21 @@ int	main(int argc, char **argv, char **envp)
 	init_tools_env(&tools.env_list, envp);
 	//convert env_list to char **env_array
 	env_array = env_list_to_array(&tools.env_list);
-	
+
 	init_tools(&tools, env_array);	//our old init_tools (can be deleted if we use linked-list all time)
 
 	string = readline("Minishell: ");
 	parse_input(string, &tokens_head);
-	// print_token_list(&tokens_head);
+	// print_token_list(&tokens_head, FALSE);
 	printf("-----------------------\n");
 	expander(&tokens_head, &tools);
 	parse_cmds(&tokens_head, &cmds_head);
 	print_cmds_list(&cmds_head);
+	printf("-----------------------\n");
 	executor(&tools,&cmds_head);
 	free(string);
 	free_token_list(&tokens_head);
+	free_token_list(&cmds_head->redirections);
 	free_cmd_list(&cmds_head);
 	free_2d_arr(tools.envp);
 	free_2d_arr(tools.paths);

--- a/src/parsing_commands.c
+++ b/src/parsing_commands.c
@@ -31,6 +31,37 @@ int	is_builtin(char *string)
 	return (FALSE);
 }
 
+void	handle_redirection(t_commands *node_cmds, t_token *start_node)
+{
+	t_token		*l_node;
+
+	if (node_cmds->redirections == NULL)
+	{
+		node_cmds->redirections = malloc(sizeof(t_token));
+		if (!node_cmds->redirections)
+			exit(EXIT_FAILURE);
+		node_cmds->redirections->cmd = ft_strdup(start_node->next->cmd);
+		if (node_cmds->redirections->cmd == NULL)
+			exit(EXIT_FAILURE);
+		node_cmds->redirections->index = start_node->next->index;
+		node_cmds->redirections->type = start_node->next->type;
+		node_cmds->redirections->next = NULL;
+	}
+	else
+	{
+		l_node = malloc(sizeof(t_token));
+		if (!l_node)
+			exit(EXIT_FAILURE);
+		l_node->cmd = ft_strdup(start_node->next->cmd);
+		if (l_node->cmd == NULL)
+			exit(EXIT_FAILURE);
+		l_node->index = start_node->next->index;
+		l_node->type = start_node->next->type;
+		l_node->next = NULL;
+		add_node_back((void **)&node_cmds->redirections, l_node, TOKEN_LIST);
+	}
+}
+
 void	create_cmd(t_token *start_node, t_token *target_node,
 		t_commands **cmd_head, int s_cmds)
 {
@@ -63,7 +94,7 @@ void	create_cmd(t_token *start_node, t_token *target_node,
 		}
 		if (start_node->type == REDIRECTION || start_node->type == A_REDIRECTION)
 		{
-			node_cmds->redirections = start_node->next;
+			handle_redirection(node_cmds, start_node);
 			redirection = TRUE;
 		}
 		if (is_builtin(start_node->cmd))
@@ -103,13 +134,15 @@ void	parse_cmds(t_token **tokens_head, t_commands **cmd_head)
 		return ;
 	while (node_token->next != NULL)
 	{
-		if (node_token->next->type != LITERAL && node_token->next->type != PIPE)
+		if (node_token->next->type != LITERAL && node_token->next->type != PIPE && redirection == FALSE)
 		{
-			redirection = !redirection;
+			redirection = TRUE;
 			s_cmds += 2;
 		}
 		if (redirection == FALSE)
+		{
 			s_cmds++;
+		}
 		if (node_token->type == PIPE)
 		{
 			// printf("Creating new command.\n");

--- a/src/print.c
+++ b/src/print.c
@@ -28,7 +28,7 @@ void	print_2d_array(char **arr)
 /*
 	Prints contents of t_token linked_list.
 */
-void	print_token_list(t_token **lst_head)
+void	print_token_list(t_token **lst_head, int print_redirection)
 {
 	t_token	*node;
 
@@ -37,7 +37,12 @@ void	print_token_list(t_token **lst_head)
 		return ;
 	while (node)
 	{
-		printf("Lexer: {%s} | Type: {%d} | Index: {%d}\n", node->cmd, node->type, node->index);
+		if (print_redirection == TRUE && node->next == NULL)
+			printf("Final Output Redirection: {%s}\n", node->cmd);
+		else if (print_redirection == TRUE)
+			printf("Redirection: {%s}\n", node->cmd);
+		else
+			printf("Lexer: {%s} | Type: {%d} | Index: {%d}\n", node->cmd, node->type, node->index);
 		node = node->next;
 	}
 }
@@ -62,7 +67,7 @@ void	print_cmds_list(t_commands **lst_head)
 			i++;
 		}
 		if (node->redirections)
-			printf("Redirection: {%s}\n", node->redirections->cmd);
+			print_token_list(&node->redirections, TRUE);
 		else
 			printf("Redirection: {%p}.\n", node->redirections);
 		printf("Builtin: {%s}\n", node->builtin);


### PR DESCRIPTION
t_commands struct now has *redirections linked list instead of only 1 node. This allows for following:
	ls > out > out1 > out2.
Before would only return out2 and would ignore out & out1. Now Naji is able to open all files even if everything will only be written to out2.

Also fixed segfault that would happen because too many nodes were malloced during command creation. 