### PR TITLE
fix execute_last_cmd(builtin) improve: cd,echo,

### DIFF
--- a/include/builtin.h
+++ b/include/builtin.h
@@ -17,26 +17,37 @@
 # include <stdbool.h>
 
 int (*execute_builtin(char *arg))(t_tools *tools, char **simple_cmd);
-int		mini_pwd(t_tools *tools, char **simple_cmd);
-int		mini_echo(t_tools *tools, char **simple_cmd);
-int		mini_env(t_tools *tools, char **simple_cmd);
-int		mini_cd(t_tools *tools, char **simple_cmd);
-int		mini_echo_option(char *str);
-int		mini_export(t_tools *tools, char **simple_cmd);
-void	update_pwd_env(t_tools *tools);
-int		mini_unset(t_tools *tools, char **simple_cmd);
+/* PWD */
+int			mini_pwd(t_tools *tools, char **simple_cmd);
+/* echo */
+int			mini_echo(t_tools *tools, char **simple_cmd);
+static int	mini_echo_option(char *str);
+static int	mini_echo_cheker(char *str);
+char		*echo_home(char *str);
+/* export */
+int	mini_export(t_tools *tools,
+				char **simple_cmd);
 
+/* cd */
+int			mini_cd(t_tools *tools, char **simple_cmd);
+void		update_pwd_env(t_tools *tools);
+/* unset */
+int			mini_unset(t_tools *tools, char **simple_cmd);
+/* exit */
+int			mini_exit(t_tools *tools, char **simple_cmd);
+/* env */
+int			mini_env(t_tools *tools, char **simple_cmd);
 //env_list_func
-t_env	*env_new_node(char *env);
-t_env	*env_last(t_env *node);
-int		env_size(t_env *node);
-void	env_add_back(t_env **list, t_env *new);
-int		env_del_one(t_env **list, char *key);
+t_env		*env_new_node(char *env);
+t_env		*env_last(t_env *node);
+int			env_size(t_env *node);
+void		env_add_back(t_env **list, t_env *new);
+int			env_del_one(t_env **list, char *key);
 
-void	init_tools_env(t_env **env_list, char **envp);
-void	prinft_env(t_env **list);
-char	**env_list_to_array(t_env **env_list);
-void	free_env_list(t_env **env_list);
-t_env	*find_env_by_key(t_env **env_list, char *key);
+void		init_tools_env(t_env **env_list, char **envp);
+void		prinft_env(t_env **list);
+char		**env_list_to_array(t_env **env_list);
+void		free_env_list(t_env **env_list);
+t_env		*find_env_by_key(t_env **env_list, char *key);
 
 #endif

--- a/src/builtins/builtin_utils.c
+++ b/src/builtins/builtin_utils.c
@@ -26,7 +26,8 @@ int	(*execute_builtin(char *args))(t_tools *tools, char **simple_cmd)
 		"echo",
 		"pwd",
 		"export",
-		"unset"
+		"unset",
+		"exit"
 	};
 	static int	(*builtin_func[])(t_tools *tools, char **simple_cmd) = {
 		&mini_cd,
@@ -34,7 +35,8 @@ int	(*execute_builtin(char *args))(t_tools *tools, char **simple_cmd)
 		&mini_echo,
 		&mini_pwd,
 		&mini_export,
-		&mini_unset};
+		&mini_unset,
+		&mini_exit};
 
 	i = 0;
 	while (i < (sizeof(buildin_func_list) / sizeof(char *)))

--- a/src/builtins/mini_cd.c
+++ b/src/builtins/mini_cd.c
@@ -30,7 +30,7 @@ int	mini_cd(t_tools *tools, char **simple_cmd)
 		else
 		{
 			ft_putstr_fd("cd: OLDPWD not set", STDERR_FILENO);
-			return (0);
+			return (EXIT_FAILURE);
 		}
 	}
 	else if (simple_cmd[1][0] == '~')
@@ -51,18 +51,27 @@ int	mini_cd(t_tools *tools, char **simple_cmd)
 		}
 	}
 	else if (simple_cmd[1][0] == '.')
-	{
 		path = simple_cmd[1];
+	else	//cd src (going to child-directory)
+	{
+		path = getcwd(NULL, sizeof(PATH_MAX));
+		path = ft_strjoin(path,"/");
+		path = ft_strjoin(path,simple_cmd[1]);
 	}
 	tools->old_pwd = getcwd(NULL, sizeof(PATH_MAX));
 	printf("check_path=%s\n", path);
-	chdir(path);
+	if (chdir(path) < 0)
+	{
+		printf("cd: %s: No such file or directory\n",simple_cmd[1]);
+		return(EXIT_FAILURE);
+	}
+	//should protect receiving current DIR
 	tools->pwd = getcwd(NULL, sizeof(PATH_MAX));
 	printf("OLDPWD =%s\n", tools->old_pwd);
 	printf("PWD =%s\n", tools->pwd);
 	update_pwd_env(tools);
 	printf("\n==============\n");
-	mini_env(tools, NULL);
+	// mini_env(tools, NULL);
 	return (0);
 }
 

--- a/src/builtins/mini_echo.c
+++ b/src/builtins/mini_echo.c
@@ -17,7 +17,7 @@
 	check if there "-n" option for echo
 	ex: echo -nnnnn hey (should not print with new_line)
  */
-int	mini_echo_option(char *str)
+static int	mini_echo_option(char *str)
 {
 	while (*str != '\0')
 	{
@@ -30,36 +30,51 @@ int	mini_echo_option(char *str)
 	return (0);
 }
 
-int	mini_echo(t_tools *tools, char **simple_cmd)
+static int	mini_echo_cheker(char *str)
 {
-	int		i;
-	char	*tmp;
-
-	i = 1;
-	tmp = "";
-	(void)tools;
-	if (simple_cmd[1] == '\0')
+	if (!str || str == '\0')
 	{
 		ft_putstr_fd("\n", STDOUT_FILENO);
 		return (0);
 	}
-	while (mini_echo_option(simple_cmd[i]) == 0)
-		i++;
-	while (simple_cmd[i] != NULL && simple_cmd[i] != '\0')
+	return (1);
+}
+
+char	*echo_home(char *str)
+{
+	char	*tmp;
+
+	tmp = "";
+	tmp = getenv("HOME");
+	ft_putstr_fd(tmp, STDOUT_FILENO);
+	str = ft_substr(str, 1, ft_strlen(str));
+	return (str);
+}
+
+int	mini_echo(t_tools *tools, char **simple_cmd)
+{
+	int	i;
+
+	i = 1;
+	(void)tools;
+	if (mini_echo_cheker(simple_cmd[1]))
 	{
-		if (simple_cmd[i][0] == '~')
+		while (mini_echo_option(simple_cmd[i]) == 0)
+			i++;
+		while (simple_cmd[i] != NULL && simple_cmd[i] != '\0')
 		{
-			tmp = getenv("HOME");
-			ft_putstr_fd(tmp, STDOUT_FILENO);
-			simple_cmd[i] = ft_substr(simple_cmd[i], 1,
-					ft_strlen(simple_cmd[i]));
+			if (simple_cmd[i][0] == '~')
+			{
+				simple_cmd[i] = echo_home(simple_cmd[i]);
+			}
+			ft_putstr_fd(simple_cmd[i], STDOUT_FILENO);
+			if (simple_cmd[i + 1] != NULL)
+				ft_putstr_fd(" ", STDOUT_FILENO);
+			i++;
 		}
-		ft_putstr_fd(simple_cmd[i], STDOUT_FILENO);
-		if (simple_cmd[i + 1] != NULL)
-			ft_putstr_fd(" ", STDOUT_FILENO);
-		i++;
+		if (mini_echo_option(simple_cmd[1]) != 0)
+			ft_putstr_fd("\n", STDOUT_FILENO);
+		return (0);
 	}
-	if (mini_echo_option(simple_cmd[1]) != 0)
-		ft_putstr_fd("\n", STDOUT_FILENO);
-	return (0);
+	return (1);
 }

--- a/src/builtins/mini_exit.c
+++ b/src/builtins/mini_exit.c
@@ -1,33 +1,22 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        ::::::::            */
-/*   mini_env.c                                         :+:    :+:            */
+/*   mini_exit.c                                        :+:    :+:            */
 /*                                                     +:+                    */
 /*   By: nakanoun <nakanoun@student.codam.nl>         +#+                     */
 /*                                                   +#+                      */
-/*   Created: 2023/05/17 15:14:20 by nakanoun      #+#    #+#                 */
-/*   Updated: 2023/05/17 15:14:20 by nakanoun      ########   odam.nl         */
+/*   Created: 2023/05/18 21:10:14 by nakanoun      #+#    #+#                 */
+/*   Updated: 2023/05/18 21:10:14 by nakanoun      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "builtin.h"
 #include "executor.h"
 
-int	mini_env(t_tools *tools, char **simple_cmd)
+int	mini_exit(t_tools *tools, char **simple_cmd)
 {
-	t_env	*env;
-
-	env = tools->env_list;
-	if (simple_cmd[1] == NULL)
-	{
-		while (env)
-		{
-			ft_putstr_fd(env->key, STDOUT_FILENO);
-			ft_putendl_fd(env->value, STDOUT_FILENO);
-			env = env->next;
-		}
-		return (0);
-	}
-	printf("env: %s: No such file or directory", simple_cmd[1]);
-	return (127);
+	(void)tools;
+	(void)simple_cmd;
+	printf("shoud exit form the program and free everything\n");
+	return (0);
 }

--- a/src/builtins/mini_export.c
+++ b/src/builtins/mini_export.c
@@ -29,7 +29,6 @@ static int	check_input(char *export_str)
 			}
 			else if (*export_str == 0)
 			{
-				// ft_strlcat(export_str, "=", ft_strlen(export_str ) + 1);
 				return (0);
 			}
 			return (0);
@@ -66,6 +65,7 @@ void	print_export_env(t_tools *tools)
 		env = env->next;
 	}
 }
+
 int	mini_export(t_tools *tools, char **simple_cmd)
 {
 	int		i;

--- a/src/executor/executor.c
+++ b/src/executor/executor.c
@@ -26,6 +26,8 @@
  */
 void	executor(t_tools *tools, t_commands **cmd_head)
 {
+	if ((*cmd_head) == NULL)
+		exit(0);
 	if ((*cmd_head)->next == NULL)
 	{
 		if ((*cmd_head)->redirections)
@@ -101,11 +103,11 @@ void	multi_pipex_process(t_tools *tools, t_commands **cmd_head, int *in)
 			execute_builtin(node->cmds[0])(tools, node->cmds);
 			exit(0); //should return the return value from builtin
 		}
-			cmd_path = find_cmd_path(tools, node->cmds);
-			if (!cmd_path)
-				ft_putstr_fd("from find_path\n", 2);
-			if (execve(cmd_path, node->cmds, NULL) == -1)
-				ft_putstr_fd("execve:\n", 2);
+		cmd_path = find_cmd_path(tools, node->cmds);
+		if (!cmd_path)
+			ft_putstr_fd("from find_path\n", 2);
+		if (execve(cmd_path, node->cmds, NULL) == -1)
+			ft_putstr_fd("execve:\n", 2);
 	} //parent process
 	close(fd[1]);
 	close(*in);
@@ -123,6 +125,12 @@ void	last_cmd(t_tools *tools, t_commands **last_cmd)
 	pid = fork();
 	if (pid == 0)
 	{
+		if ((*last_cmd)->builtin)
+		{
+			// printf("<<<<<Buildin>>>>\n");
+			execute_builtin((*last_cmd)->cmds[0])(tools, (*last_cmd)->cmds);
+			exit(0);
+		}
 		cmd_path = find_cmd_path(tools, (*last_cmd)->cmds);
 		if (!cmd_path)
 			ft_putstr_fd("from find_path\n", 2);
@@ -156,7 +164,7 @@ int	execute_onc_cmd(t_tools *tools, t_commands **cmd_head)
 	t_commands	*node;
 
 	node = *cmd_head;
-	// already did this previously in execute function. 
+	// already did this previously in execute function.
 	// if (node->redirections)
 	// {
 	// 	redirection(node);


### PR DESCRIPTION
fix last_cmd builtin ex: ls | cd ..
improve cd to go to child DIR ex:
cd src/builtin
improve echo (notminette friendly), no leaks when cmd in empty ex: echo
echo $NOT_VAR