### PR TITLE
protect ft_strdup, fix expand(~), protect cd, exit

### DIFF
--- a/Lib/libft/ft_strdup.c
+++ b/Lib/libft/ft_strdup.c
@@ -1,14 +1,15 @@
 /* ************************************************************************** */
 /*                                                                            */
-/*                                                        :::      ::::::::   */
-/*   ft_strdup.c                                        :+:      :+:    :+:   */
-/*                                                    +:+ +:+         +:+     */
-/*   By: ysrondy <ysrondy@student.codam.nl>         +#+  +:+       +#+        */
-/*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2022/10/09 08:40:59 by ysrondy           #+#    #+#             */
+/*                                                        ::::::::            */
+/*   ft_strdup.c                                        :+:    :+:            */
+/*                                                     +:+                    */
+/*   By: ysrondy <ysrondy@student.codam.nl>           +#+                     */
+/*                                                   +#+                      */
+/*   Created: 2022/10/09 08:40:59 by ysrondy       #+#    #+#                 */
 /*   Updated: 2022/10/23 16:51:40 by ysrondy       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
+
 #include <stdlib.h>
 
 char	*ft_strdup(const char *s)
@@ -17,6 +18,8 @@ char	*ft_strdup(const char *s)
 	char	*ptr;
 
 	i = 0;
+	if (!s)
+		return (NULL);
 	while (s[i] != '\0')
 		i++;
 	ptr = (char *)malloc(sizeof(char) * (i + 1));

--- a/Lib/libft/ftp_strdup.c
+++ b/Lib/libft/ftp_strdup.c
@@ -15,9 +15,11 @@
 
 char	*ftp_strdup(char *s)
 {
-	char	*str;
-	size_t	len;
+	char *str;
+	size_t len;
 
+	if (!s || s[0] == '\0')
+		return (NULL);
 	len = ft_strlen(s);
 	str = ft_calloc((len + 1), sizeof(char));
 	if (!str)

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 
 NAME := minishell
 
-CFLAGS := -Wall -Wextra -Werror #-g -fsanitize=address,undefined
+CFLAGS := -Wall -Wextra -Werror -g -fsanitize=address,undefined
 
 #Lib
 LIB_LIBFT = ./lib/libft/libft.a

--- a/src/builtins/builtin_utils.c
+++ b/src/builtins/builtin_utils.c
@@ -20,7 +20,7 @@
 int	(*execute_builtin(char *args))(t_tools *tools, char **simple_cmd)
 {
 	unsigned long	i;
-	const char		*buildin_func_list[] = {
+	const char		*builtin_func_list[] = {
 		"cd",
 		"env",
 		"echo",
@@ -39,11 +39,12 @@ int	(*execute_builtin(char *args))(t_tools *tools, char **simple_cmd)
 		&mini_exit};
 
 	i = 0;
-	while (i < (sizeof(buildin_func_list) / sizeof(char *)))
+	while (i < (sizeof(builtin_func_list) / sizeof(char *)))
 	{
-		if (ft_strncmp(args, buildin_func_list[i], ft_strlen(args)) == 0)
+		if (ft_strncmp(args, builtin_func_list[i], ft_strlen(args)) == 0)
 			return ((*builtin_func[i]));
 		i++;
 	}
 	return (0);
 }
+

--- a/src/builtins/mini_exit.c
+++ b/src/builtins/mini_exit.c
@@ -46,8 +46,10 @@ void	free_all_exit(t_tools *tools)
 {
 	// tools->loop = false;
 	free_env_list(&tools->env_list);
-	free(tools->pwd);
-	free(tools->old_pwd);
+	if (tools->pwd != NULL || tools->pwd != '\0')
+		free(tools->pwd);
+	if (tools->old_pwd != NULL || tools->old_pwd != '\0')
+		free(tools->old_pwd);
 	free(tools);
 	exit(g_exit_status);
 }

--- a/src/builtins/mini_pwd.c
+++ b/src/builtins/mini_pwd.c
@@ -22,6 +22,9 @@ int	mini_pwd(t_tools *tools, char **simple_cmd)
 	if (getcwd(cwd, sizeof(cwd)) != NULL)
 		printf("Current working dir: %s\n", cwd);
 	else
+	{
 		perror("getcwd() error");
-	return (0);
+		return (EXIT_FAILURE);
+	}
+	return (EXIT_SUCCESS);
 }

--- a/src/expander.c
+++ b/src/expander.c
@@ -168,31 +168,29 @@ void	handle_exit_status(t_token *node)
 
 void	handle_home_dir(t_token *node, t_tools *tools)
 {
-	t_env	*env;
 	char	*path;
 	char	*final_path;
 
-	env = find_env_by_key(&tools->env_list, "HOME");
 	if (node->cmd[1] == '/')
 	{
-		path = ft_strdup(env->value);
+		path = getenv("HOME");
 		if (!path)
 			exit(EXIT_FAILURE);
 		final_path = ft_strjoin(path, (&node->cmd[1]));
 		if (!final_path)
 			exit(EXIT_FAILURE);
-		free(path);
 		free(node->cmd);
 		node->cmd = final_path;
 	}
 	else if (node->cmd[1] == '\0')
 	{
 		free(node->cmd);
-		node->cmd = ft_strdup(env->value);
+		node->cmd = ft_strdup(getenv("HOME"));
 		return ;
 	}
 	else
 		return ;
+	(void)(tools);
 }
 
 


### PR DESCRIPTION
- protect ft_strdup(NULL) returns NULL without segfaults, fix expand (~): use getenv("HOME"), instead of getting from env_list, so now if `UNSET HOME`, will now SEGFAULTS when expand ~ protect cd: when receiving current dir, ex:
`cd dir1/dir2/,` then remove dir1 && `cd ..`
will print an error retrieving the current directory:
protect exit: freeing (tools->pwd) && (tools->OLDPWD)