### PR TITLE
NORM exit, env_list, error(env_print),export

### DIFF
--- a/src/builtins/mini_env.c
+++ b/src/builtins/mini_env.c
@@ -27,7 +27,9 @@ int	mini_env(t_tools *tools, char **simple_cmd)
 				if (env->has_value == TRUE)
 				{
 					ft_putstr_fd(env->key, STDOUT_FILENO);
-					ft_putendl_fd(env->value, STDOUT_FILENO);
+					if (env->value)
+						ft_putstr_fd(env->value, STDOUT_FILENO);
+					ft_putstr_fd("\n", STDOUT_FILENO);
 				}
 				env = env->next;
 			}

--- a/src/builtins/mini_exit.c
+++ b/src/builtins/mini_exit.c
@@ -29,22 +29,9 @@ static bool	is_all_numric(char *str)
 	}
 	return (true);
 }
-/* static int	exit_args(char **simple_cmd)
-{
-	int	i;
 
-	i = 1;
-	while (simple_cmd[i] != NULL)
-	{
-		if (is_all_numric(simple_cmd[i]))
-			i++;
-	}
-	return (0);
-}
- */
 void	free_all_exit(t_tools *tools)
 {
-	// tools->loop = false;
 	free_env_list(&tools->env_list);
 	if (tools->pwd != NULL || tools->pwd != '\0')
 		free(tools->pwd);
@@ -61,6 +48,22 @@ void	error_exit(char *cmd)
 	ft_putstr_fd(": numeric argument required\n", STDOUT_FILENO);
 }
 
+void	exit_with_number(t_tools *tools, char **simple_cmd)
+{
+	if (!tools->has_pipe)
+		ft_putendl_fd("exit", STDOUT_FILENO);
+	if (simple_cmd[2] == NULL)
+	{
+		g_exit_status = ft_atoi(simple_cmd[1]);
+		free_all_exit(tools);
+	}
+	else if (simple_cmd[2] != NULL)
+	{
+		g_exit_status = 1;
+		ft_putstr_fd("Minishell: exit: too many arguments\n", STDERR_FILENO);
+	}
+}
+
 int	mini_exit(t_tools *tools, char **simple_cmd)
 {
 	if (simple_cmd[1] == NULL)
@@ -72,21 +75,7 @@ int	mini_exit(t_tools *tools, char **simple_cmd)
 	else
 	{
 		if (is_all_numric(simple_cmd[1]) == true)
-		{
-			if (!tools->has_pipe)
-				ft_putendl_fd("exit", STDOUT_FILENO);
-			if (simple_cmd[2] == NULL)
-			{
-				g_exit_status = ft_atoi(simple_cmd[1]);
-				free_all_exit(tools);
-			}
-			else if (simple_cmd[2] != NULL)
-			{
-				g_exit_status = 1;
-				ft_putstr_fd("Minishell: exit: too many arguments\n",
-								STDERR_FILENO);
-			}
-		}
+			exit_with_number(tools, simple_cmd);
 		else if (is_all_numric(simple_cmd[1]) == false)
 		{
 			g_exit_status = 255;

--- a/src/builtins/mini_export.c
+++ b/src/builtins/mini_export.c
@@ -28,21 +28,16 @@ static int	check_input(char *export_str) //error!
 				return (1);
 			}
 			else if (*export_str == 0)
-			{
 				return (0);
-			}
 			return (0);
 		}
 		else
-		{
-			printf("is_NOT_alpha\n");
-			return (1);
-		}
+			return(EXIT_FAILURE);
 	}
 	return (1);
 }
 
-void	print_export_env(t_tools *tools)
+static int	print_export_env(t_tools *tools)
 {
 	t_env	*env;
 
@@ -63,6 +58,8 @@ void	print_export_env(t_tools *tools)
 		}
 		env = env->next;
 	}
+	g_exit_status = 0;
+	return(EXIT_SUCCESS);
 }
 
 int	mini_export(t_tools *tools, char **simple_cmd)
@@ -74,13 +71,11 @@ int	mini_export(t_tools *tools, char **simple_cmd)
 	env_node = NULL;
 	i = 0;
 	if (simple_cmd[1] == NULL || simple_cmd[1][0] == '\0')
-	{
-		print_export_env(tools);
-		return (0);
-	}
+		return (print_export_env(tools));
 	i = 1;
 	while (simple_cmd[i] != NULL)
 	{
+		printf("cmd[1]=%s\tcmd[2]=%s\n", simple_cmd[1], simple_cmd[2]);
 		if (!check_input(simple_cmd[i]))
 		{
 			env_node = modify_env_value(&tools->env_list, simple_cmd[i]);
@@ -88,15 +83,18 @@ int	mini_export(t_tools *tools, char **simple_cmd)
 				env_node = env_new_node(simple_cmd[i]);
 			printf("key:%s\tvalue:%s\n", env_node->key, env_node->value);
 			env_add_back(&tools->env_list, env_node);
+			g_exit_status = 0;
 		}
 		else
 		{
+			ft_putstr_fd("Minishell: export: ", STDERR_FILENO);
+			ft_putstr_fd(simple_cmd[i], STDERR_FILENO);
+			ft_putstr_fd(": not a valid identifier\n", STDERR_FILENO);
 			g_exit_status = 1;
-			printf("ERROR\n");
 		}
 		i++;
 	}
-	return (0);
+	return (g_exit_status);
 }
 
 t_env	*modify_env_value(t_env **env_list, char *simple_command)

--- a/src/executor/env_list.c
+++ b/src/executor/env_list.c
@@ -15,27 +15,20 @@
 t_env	*env_new_node(char *env)
 {
 	int		i;
-	int		len;
-	int		j;
 	t_env	*new_node;
 
 	i = 0;
-	len = ft_strlen(env);
 	new_node = (t_env *)malloc(sizeof(t_env));
 	if (!new_node)
 		return (NULL);
 	new_node->value = NULL;
-	while (env[i])
-	{
-		if (env[i] == '=')
-		{
-			new_node->key = ft_substr(env, 0, i + 1);
-			j = len - i;
-			new_node->value = ft_substr(env, i + 1, j);
-			new_node->has_value = true;
-			break ;
-		}
+	while (env[i] != '\0' && env[i] != '=')
 		i++;
+	if (env[i] == '=')
+	{
+		new_node->key = ft_substr(env, 0, i + 1);
+		new_node->value = ft_substr(env, i + 1, ft_strlen(env) - i);
+		new_node->has_value = true;
 	}
 	if (!new_node->value) //this for empty value..
 	{


### PR DESCRIPTION
mini_exit is now norm-free,
improved env print error with exit code
improved export errors but still needs to be finished. Waiting to be parsed correctly,
env_list is NORM friendly