### PR TITLE
empty inputs, exit prints, 1cmd_handler

### DIFF
--- a/include/executor.h
+++ b/include/executor.h
@@ -32,11 +32,12 @@ void	executor(t_tools *tools, t_commands **cmd_head);
 char	*check_current_dir(char *cmd);
 
 //execute
+void	one_cmd_handler(t_tools *tools, t_commands **cmd_head);
 void	execute_onc_cmd(t_tools *tools, t_commands **cmd_head);
 int		close_pipes(int *fd, int old_fd);
 //multi cmnds
-void	multi_comands(t_tools *tools, t_commands **cmd_head);
-int	multi_pipex_process(t_tools *tools, t_commands **cmd_head, int old_fd,
+void	multi_commands_handler(t_tools *tools, t_commands **cmd_head);
+int		multi_pipex_process(t_tools *tools, t_commands **cmd_head, int old_fd,
 			int *fd);
 pid_t	last_cmd(t_tools *tools, t_commands **last_cmd, int old_fd);
 void	multi_v2(t_tools *tools, t_commands **cmd_head, int *fd);
@@ -45,8 +46,7 @@ void	wait_last_pid(pid_t last_pid);
 //redirection
 int		redirection(t_commands *cmd);
 void	ft_dup2_check(int old, int new);
-int		create_heredoc(t_token *redirection, t_commands *cmd,
-			t_tools *tools);
+int		create_heredoc(t_token *redirection, t_commands *cmd, t_tools *tools);
 int		is_heredoc(t_commands **cmd, t_tools *tools);
 
 //error_handling

--- a/src/builtins/mini_cd.c
+++ b/src/builtins/mini_cd.c
@@ -63,7 +63,7 @@ void	update_pwd_env(t_tools *tools, char *tmp_opwd)
 	t_env	*old_pwd;
 
 	tools->old_pwd = ftp_strdup(tmp_opwd);
-	if (tools->pwd || tools->pwd != '\0')
+	if (tools->pwd || tools->pwd[0] != '\0')
 		free(tools->pwd);
 	tools->pwd = getcwd(NULL, sizeof(PATH_MAX));
 	if (!tools->pwd)

--- a/src/builtins/mini_exit.c
+++ b/src/builtins/mini_exit.c
@@ -33,9 +33,9 @@ static bool	is_all_numric(char *str)
 void	free_all_exit(t_tools *tools)
 {
 	free_env_list(&tools->env_list);
-	if (tools->pwd != NULL || tools->pwd != '\0')
+	if (tools->pwd != NULL)
 		free(tools->pwd);
-	if (tools->old_pwd != NULL || tools->old_pwd != '\0')
+	if (tools->old_pwd != NULL)
 		free(tools->old_pwd);
 	free(tools);
 	exit(g_exit_status);
@@ -43,15 +43,15 @@ void	free_all_exit(t_tools *tools)
 
 void	error_exit(char *cmd)
 {
-	ft_putstr_fd("Minishell: exit: ", STDOUT_FILENO);
-	ft_putstr_fd(cmd, STDOUT_FILENO);
-	ft_putstr_fd(": numeric argument required\n", STDOUT_FILENO);
+	ft_putstr_fd("Minishell: exit: ", STDERR_FILENO);
+	ft_putstr_fd(cmd, STDERR_FILENO);
+	ft_putstr_fd(": numeric argument required\n", STDERR_FILENO);
 }
 
 void	exit_with_number(t_tools *tools, char **simple_cmd)
 {
 	if (!tools->has_pipe)
-		ft_putendl_fd("exit", STDOUT_FILENO);
+		ft_putendl_fd("exit", STDERR_FILENO);
 	if (simple_cmd[2] == NULL)
 	{
 		g_exit_status = ft_atoi(simple_cmd[1]);
@@ -69,7 +69,7 @@ int	mini_exit(t_tools *tools, char **simple_cmd)
 	if (simple_cmd[1] == NULL)
 	{
 		if (!tools->has_pipe)
-			ft_putendl_fd("exit", STDOUT_FILENO);
+			ft_putendl_fd("exit", STDERR_FILENO);
 		free_all_exit(tools);
 	}
 	else
@@ -80,7 +80,7 @@ int	mini_exit(t_tools *tools, char **simple_cmd)
 		{
 			g_exit_status = 255;
 			if (tools->has_pipe == false)
-				ft_putendl_fd("exit", STDOUT_FILENO);
+				ft_putendl_fd("exit", STDERR_FILENO);
 			ft_putstr_fd("Minishell: exit: ", STDERR_FILENO);
 			ft_putstr_fd(simple_cmd[1], STDERR_FILENO);
 			ft_putstr_fd(": numeric argument required\n", STDERR_FILENO);

--- a/src/executor/executor.c
+++ b/src/executor/executor.c
@@ -33,14 +33,22 @@ void	executor(t_tools *tools, t_commands **cmd_head)
 	int	fd_i;
 	int	fd_o;
 
-	if ((*cmd_head) == NULL)
-		exit(0);
+	if (!(*cmd_head))
+		return;
 	if (is_heredoc(cmd_head, tools) == ERROR)
 		return ;
 	fd_i = dup(STDIN_FILENO);
 	fd_o = dup(STDOUT_FILENO);
 	if ((*cmd_head)->next == NULL)
-	{
+		one_cmd_handler(tools, cmd_head);
+	if ((*cmd_head)->next != NULL)
+		multi_commands_handler(tools, cmd_head);
+	dup2(fd_i, STDIN_FILENO);
+	dup2(fd_o, STDOUT_FILENO);
+}
+
+void one_cmd_handler(t_tools *tools, t_commands **cmd_head)
+{
 		tools->has_pipe = false;
 		if ((*cmd_head)->redirections)
 			if (redirection((*cmd_head)))
@@ -53,11 +61,6 @@ void	executor(t_tools *tools, t_commands **cmd_head)
 		}
 		if ((*cmd_head)->cmds[0])
 			execute_onc_cmd(tools, cmd_head);
-	}
-	if ((*cmd_head)->next != NULL)
-		multi_comands(tools, cmd_head);
-	dup2(fd_i, STDIN_FILENO);
-	dup2(fd_o, STDOUT_FILENO);
 }
 /*
 	this func will split the commands to two parts:
@@ -65,7 +68,7 @@ void	executor(t_tools *tools, t_commands **cmd_head)
 	and run the last command separately
  */
 
-void	multi_comands(t_tools *tools, t_commands **cmd_head)
+void	multi_commands_handler(t_tools *tools, t_commands **cmd_head)
 {
 	t_commands	*node;
 	int			old_fd;

--- a/src/executor/heredoc.c
+++ b/src/executor/heredoc.c
@@ -142,7 +142,7 @@ int	create_heredoc(t_token *redirection, t_commands *cmd, t_tools *tools)
 		file = open(path, O_CREAT | O_WRONLY | O_TRUNC, 0644);
 		if (file < 0)
 			return (error_file_handling(redirection->cmd));
-		dprintf(2, "index=%dtools index=%d\n", redirection->index,
+		dprintf(2, "index=%d  tools index=%d\n", redirection->index,
 				tools->heredoc);
 		while (1)
 		{

--- a/src/main.c
+++ b/src/main.c
@@ -10,7 +10,6 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-
 /*
 Hello Naji
 Project needs to be divided into the following sections:
@@ -21,7 +20,10 @@ You will need to read the input from the user and then parse it into a series of
 
 Creating a Command Execution Engine:
 Once the input is parsed, you will need to execute the command.
-For this, you will need to create a command execution engine that can execute different types of commands, such as built-in commands like cd and exit, and external commands like ls, grep, etc.
+For this,
+	you will need to create a command execution engine that can execute different types of commands,
+	such as built-in commands like cd and exit, and external commands like ls,
+	grep, etc.
 
 Implementing Built-In Commands:
 You will need to implement the built-in commands like cd, exit, and echo.
@@ -29,24 +31,26 @@ These commands are executed directly by the shell and do not require forking a n
 
 Implementing I/O Redirection:
 I/O redirection is an important feature of the shell that allows the user to redirect input and output from and to files.
-You will need to implement redirection using system calls like open(), close(), and dup2().
+You will need to implement redirection using system calls like open(), close(),
+	and dup2().
 
 Implementing Pipes:
-Pipes allow the user to chain together multiple commands, where the output of one command is passed as input to the next command.
+Pipes allow the user to chain together multiple commands,
+	where the output of one command is passed as input to the next command.
 You will need to implement pipes using system calls like pipe() and dup2().
 
 Implementing Job Control:
 Job control is a feature that allows the user to control and manage multiple processes running in the shell.
-You will need to implement job control using system calls like fork(), waitpid(), and kill().
+You will need to implement job control using system calls like fork(),
+	waitpid(), and kill().
 */
 
-#include "minishell.h"
-#include "executor.h"
 #include "builtin.h"
+#include "executor.h"
+#include "minishell.h"
 
 /* Variable defined here */
 int	g_exit_status = 0;
-
 
 int	main(int argc, char **argv, char **envp)
 {
@@ -58,14 +62,11 @@ int	main(int argc, char **argv, char **envp)
 	// atexit(check_leaks);
 	if (argc != 1)
 		return (EXIT_FAILURE);
-
-
 	tokens_head = NULL;
 	cmds_head = NULL;
 	tools = (t_tools *)malloc(sizeof(*tools));
-
 	init_tools_env(&tools->env_list, envp);
-	init_tools(tools);	//keep this
+	init_tools(tools); //keep this
 	g_exit_status = 0;
 	while (tools->loop)
 	{
@@ -83,14 +84,14 @@ int	main(int argc, char **argv, char **envp)
 		printf("--------EXECUTION-------------\n");
 		executor(tools, &cmds_head);
 		free_token_list(&tokens_head);
-		free_token_list(&cmds_head->redirections);
+		if (cmds_head)
+			free_token_list(&cmds_head->redirections);
 		free_cmd_list(&cmds_head);
 	}
 	// free_2d_arr(tools->envp);	//keep this
 	// free_2d_arr(tools->paths);	//keep this
-
 	//do not have to free them when submit the project
-/* 	free_env_list(&tools->env_list);
+	/* 	free_env_list(&tools->env_list);
 	free(tools->pwd);
 	free(tools->old_pwd);
 	free(tools); */


### PR DESCRIPTION
fix segfaults when just /n, no inputs,
fix mini_exit and mini_cd for FLASG,
mini_exit is now printing on STD_ERR,
separate one_cmd_handler from the executor function