### PR TITLE
Changed structure/flow of expansion & quotes.

### DIFF
--- a/include/executor.h
+++ b/include/executor.h
@@ -49,6 +49,8 @@ int		redirection(t_commands *cmd);
 void	ft_dup2_check(int old, int new);
 int		create_heredoc(t_token *redirection, t_commands *cmd, t_tools *tools);
 int		is_heredoc(t_commands **cmd, t_tools *tools);
+char	*get_expanded_arg(char *line, t_tools *tools, int *i);
+char	*expand_heredoc(char *line, t_tools *tools);
 
 //error_handling
 int		error_file_handling(char *str);

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -112,7 +112,7 @@ typedef struct s_commands
 				/* Parsing Tokens */
 int		is_whitespace(char c);
 int		find_token_type(char c, char c_next);
-void	parse_input(char *string, t_token **tokens_head);
+void	parse_input(char *string, t_token **tokens_head, t_tools *tools);
 
 				/* Parsing Dollar Expander */
 void	handle_arg_then_dollar(char *new_string, char *string, int i, int j);

--- a/src/executor/heredoc.c
+++ b/src/executor/heredoc.c
@@ -53,9 +53,47 @@ char	*get_expanded_arg(char *line, t_tools *tools, int *i)
 	}
 	str_to_be_expanded[j] = '\0';
 	expanded_string = expand_arg(str_to_be_expanded, tools);
+	if (!expanded_string)
+		exit(EXIT_FAILURE);
 	// printf("Expanded: %s to %s\n", str_to_be_expanded, expanded_string);
 	free(str_to_be_expanded);
 	return (expanded_string);
+}
+
+int	inside_single_quote_only(char *string, char c)
+{
+	int		i;
+	bool	single_quote;
+	int		single_pos;
+	bool	double_quote;
+	int		double_pos;
+
+	i = 0;
+	single_quote = false;
+	double_quote = false;
+	while (string[i])
+	{
+		if (string[i] == '"')
+		{
+			double_quote = !double_quote;
+			double_pos = i;
+		}
+		if (string[i] == '\'')
+		{
+			single_quote = !single_quote;
+			single_pos = i;
+		}
+		if (string[i] == c)
+		{
+			if (single_quote == true && (double_quote == false
+					|| (double_quote == true && single_pos < double_pos)))
+				return (true);
+			else
+				return (false);
+		}
+		i++;
+	}
+	return (false);
 }
 
 char	*expand_heredoc(char *line, t_tools *tools)
@@ -73,7 +111,8 @@ char	*expand_heredoc(char *line, t_tools *tools)
 	while (line[i] != '\0')
 	{
 		final_string[j] = line[i];
-		if (line[i] == '$' && line[i + 1] != '\0')
+		if (line[i] == '$' && line[i + 1] != '\0'
+			&& inside_single_quote_only(line, line[i]) == false)
 		{
 			expanded_string = get_expanded_arg(line, tools, &i);
 			while (expanded_string && expanded_string[x])

--- a/src/expander.c
+++ b/src/expander.c
@@ -27,6 +27,7 @@ char	*expand_arg(char *string, t_tools *tools)
 	int		len;
 	int		found_equal_sign;
 
+	printf("Trying to expand: %s\n", string);
 	env_list = tools->env_list;
 	found_equal_sign = FALSE;
 	expanded_arg = ft_strchr(string, '=');
@@ -40,6 +41,8 @@ char	*expand_arg(char *string, t_tools *tools)
 	}
 	while (env_list)
 	{
+		if (ft_strncmp(string, "$?", 2) == 0)
+			return (ft_itoa(g_exit_status));
 		if (ft_strncmp((string + 1), env_list->key, len) == 0
 			&& ft_strlen(env_list->key) >= len && env_list->key[len] == '=')
 		{

--- a/src/main.c
+++ b/src/main.c
@@ -75,10 +75,10 @@ int	main(int argc, char **argv, char **envp)
 		if (!tools->og_string)
 			exit(EXIT_FAILURE);
 		printf("\n");
-		parse_input(string, &tokens_head);
+		parse_input(string, &tokens_head, tools);
 		printf("--------PARSING---------------\n");
 		print_token_list(&tokens_head, FALSE);
-		expander(&tokens_head, tools);
+		// expander(&tokens_head, tools);
 		parse_cmds(&tokens_head, &cmds_head);
 		print_cmds_list(&cmds_head);
 		printf("--------EXECUTION-------------\n");

--- a/src/parsing_quotations.c
+++ b/src/parsing_quotations.c
@@ -71,6 +71,12 @@ char	*handle_quotations(char *string)
 	double_quote = FALSE;
 	single_quote = FALSE;
 	single_inside_double = FALSE;
+	if ((string[0] == '"' && string[1] == '"')
+		|| (string[0] == '\'' && string[1] == '\''))
+	{
+		string[0] = '\0';
+		return (string);
+	}
 	new_string = malloc(sizeof(char) * (ft_strlen(string) * 2));
 	if (!new_string)
 		exit(EXIT_FAILURE);
@@ -94,13 +100,15 @@ char	*handle_quotations(char *string)
 				// new_string[j] = ' ';
 				// j++;
 				i++;
+				while (string[i] == '"')
+					i++;
 				double_quote = TRUE;
 			}
 		}
 		if (string[i] == '\'' && double_quote == FALSE)
 		{
-			if (string[i + 1] == '$')
-				i--;
+			// if (string[i + 1] == '$')
+			// 	i--;
 			if (single_quote == TRUE)
 			{
 				// new_string[j] = ' ';
@@ -114,6 +122,8 @@ char	*handle_quotations(char *string)
 				// new_string[j] = ' ';
 				// j++;
 				i++;
+				while (string[i] == '\'')
+					i++;
 				single_quote = TRUE;
 			}
 		}


### PR DESCRIPTION
Commands are now split by white spaces only if there is no quotation marks. Otherwise treated as one large string. 
Handling of quotations & '$' in string is done immediately AFTER creating the node, not BEFORE creating the node anymore. Expansion is done the same way as heredoc, no separate logic anymore. 
Fixed numerous small bugs, parsing is in much better shape for making changes.