### PR TITLE
Added support for '~' and fixed malloc issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 
 NAME := minishell
 
-CFLAGS := -Wall -Wextra -Werror -g #-fsanitize=address,undefined
+CFLAGS := -Wall -Wextra -Werror -g -fsanitize=address,undefined
 
 #Lib
 LIB_LIBFT = ./lib/libft/libft.a

--- a/src/executor/heredoc.c
+++ b/src/executor/heredoc.c
@@ -110,6 +110,24 @@ int	inside_single_quote_only(char *string, char c)
 	return (false);
 }
 
+char	*ft_str_add_char(char *str, char c)
+{
+	char	*new_string;
+	int		i;
+
+	new_string = malloc(sizeof(char) * (ft_strlen(str) + 2));
+	i = 0;
+	while (str[i])
+	{
+		new_string[i] = str[i];
+		i++;
+	}
+	new_string[i] = c;
+	new_string[i + 1] = '\0';
+	free(str);
+	return (new_string);
+}
+
 char	*expand_heredoc(t_token *node, char *line, t_tools *tools)
 {
 	char	*expanded_string;
@@ -121,34 +139,25 @@ char	*expand_heredoc(t_token *node, char *line, t_tools *tools)
 	i = 0;
 	j = 0;
 	x = 0;
-	final_string = malloc(sizeof(char) * ft_strlen(line) * 10);
+	final_string = calloc((ft_strlen(line) + 1), sizeof(char));
 	expanded_string = NULL;
 	while (line[i] != '\0')
 	{
-		final_string[j] = line[i];
-		if (line[i] == '$' && line[i + 1] != '\0'
+		if (((line[i] == '$' && line[i + 1] != '\0') || (line[i] == '~'))
 			&& inside_single_quote_only(line, line[i]) == false
 			&& get_prev_node(tools->token_head, node)->type != HEREDOC)
 		{
 			expanded_string = get_expanded_arg(line, tools, &i, node);
-			// i think dont have to this one
-			// if (expanded_string[0] == '\0' || expanded_string[0] == '$') 
-			// 	tools->indexes[node->index] = 1;
-			while (expanded_string && expanded_string[x])
-			{
-				final_string[j] = expanded_string[x];
-				x++;
-				j++;
-			}
-			x = 0;
+			final_string = ft_strjoin(final_string, expanded_string);
+			// NEED TO FIX LEAK ABOVE ^
+			// ALSO NEED TO CHECK FOR HANDLING '~' in other cases, for example ~~.
 		}
 		else
 		{
+			final_string = ft_str_add_char(final_string, line[i]);
 			i++;
-			j++;
 		}
 	}
-	final_string[j] = '\0';
 	free(line);
 	free(expanded_string);
 	return (final_string);

--- a/src/expander.c
+++ b/src/expander.c
@@ -41,6 +41,8 @@ char	*expand_arg(char *string, t_tools *tools)
 	}
 	while (env_list)
 	{
+		if (ft_strncmp(string, "~", 1) == 0)
+			return ft_strdup(getenv("HOME"));
 		if (ft_strncmp(string, "$?", 2) == 0)
 			return (ft_itoa(g_exit_status));
 		if (ft_strncmp((string + 1), env_list->key, len) == 0

--- a/src/main.c
+++ b/src/main.c
@@ -37,7 +37,7 @@ int	main(int argc, char **argv, char **envp)
 	t_commands	*cmds_head;
 	t_tools		*tools;
 
-	atexit(check_leaks);
+	// atexit(check_leaks);
 	if (argc != 1)
 		return (EXIT_FAILURE);
 	tokens_head = NULL;
@@ -56,12 +56,12 @@ int	main(int argc, char **argv, char **envp)
 			exit(EXIT_FAILURE);
 		add_history(string);
 		parse_input(string, &tokens_head, tools);
-		// printf("\n--------LEXER---------------\n");
-		// print_token_list(&tokens_head, FALSE);
+		printf("\n--------LEXER---------------\n");
+		print_token_list(&tokens_head, FALSE);
 		parse_cmds(&tokens_head, &cmds_head);
-		// printf("\n--------COMMANDS---------------\n");
-		// print_cmds_list(&cmds_head);
-		// printf("\n--------EXECUTION-------------\n");
+		printf("\n--------COMMANDS---------------\n");
+		print_cmds_list(&cmds_head);
+		printf("\n--------EXECUTION-------------\n");
 		if (handle_syntax_error(&tokens_head, tools) != 1)
 			executor(tools, &cmds_head);
 		free_token_list(&tokens_head);


### PR DESCRIPTION
Fixed malloc issue where it wouldn't allocate sufficient memory and a segfault would occur. Need to check in other places where arbitrary amount of bytes are allocated.

Also added support for expanding ~ although this may cause other things to break so i need to check. I see already that '~' still expands which shouldn't happen.