### PR TITLE
Fixed parsing issue where || was not seperated.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ LIBFT_DIR = ./lib/libft
 
 OBJ_DIR	= obj
 
-HEADERS	:= -I ./include -I $(LIBFT_DIR) -I $(CODAM_READLINE_INCLUDE)
+HEADERS	:= -I ./include -I $(LIBFT_DIR) -I $(YOUSSEF_READLINE_INCLUDE)
 
 SRCS := src/main.c \
 		src/builtins/builtin_utils.c \
@@ -73,7 +73,7 @@ SRCS := src/main.c \
 		src/utils/utils.c \
 		src/utils/utils_extra.c \
 		src/utils/utils_parsing.c \
-		src/utils/utils_syntax.c 
+		src/utils/utils_syntax.c
 
 OBJS = $(addprefix $(OBJ_DIR)/, $(SRCS:.c=.o))
 
@@ -84,7 +84,7 @@ $(OBJ_DIR)/%.o: %.c
 		@$(CC) $(CFLAGS) $(HEADERS) -o $@ -c $<
 
 $(NAME):	 $(LIB_LIBFT) $(OBJS)
-		@$(CC) $(CFLAGS) $(HEADERS) -lreadline $(OBJS) $(LIB_LIBFT) -o $(NAME) -L $(CODAM_READLINE_LIB)
+		@$(CC) $(CFLAGS) $(HEADERS) -lreadline $(OBJS) $(LIB_LIBFT) -o $(NAME) -L $(YOUSSEF_READLINE_LIB)
 		@printf "Compiled ./minishell executable succesfully.\n"
 
 

--- a/src/executor/executor.c
+++ b/src/executor/executor.c
@@ -72,9 +72,6 @@ void	execve_cmd(t_tools *tools, t_commands **cmd_head)
 
 char	*check_current_dir(char *cmd)
 {
-	int	i;
-
-	i = 0;
 	if (ft_strchr(cmd, '/') || cmd[0] == '.')
 		return (cmd);
 	return (NULL);

--- a/src/parsing/parsing_extra.c
+++ b/src/parsing/parsing_extra.c
@@ -45,45 +45,45 @@ int	should_expand(char *line, t_tools *tools, t_token *node, int i)
 	return (false);
 }
 
-char	*add_spaces_if_needed(char *str, int in_quotes, int i, int j)
+char	*add_spaces_if_needed(char *str, int i, int j, char *new_string)
 {
-	char	*result;
-
-	result = malloc(sizeof(char) * ((strlen(str) + 1) * 2));
-	if (!result)
-		return (NULL);
 	while (str[i] != '\0')
 	{
-		if (str[i] == '\"' || str[i] == '\'')
-			in_quotes = !in_quotes;
-		if (!in_quotes && (str[i] == '>' || str[i] == '<' || str[i] == '|'))
+		if (is_inside_quote(str, i) == NO_QUOTATION)
 		{
-			if (i > 0 && str[i - 1] != ' ')
-				result[j++] = ' ';
-			result[j++] = str[i++];
-			if (str[i] == str[i - 1])
-				result[j++] = str[i++];
-			if (str[i] != ' ')
-				result[j++] = ' ';
+			if (str[i] == '>' || str[i] == '<' || str[i] == '|')
+			{
+				if (is_whitespace(str[i - 1]) == false)
+					new_string[j++] = ' ';
+				new_string[j++] = str[i++];
+				if (str[i] == str[i - 1] && str[i] != '|')
+					new_string[j++] = str[i++];
+				if (str[i] != '>' && str[i] != '<' && str[i] != '|'
+					&& is_whitespace(str[i]) == false)
+					new_string[j++] = ' ';
+			}
+			else
+				new_string[j++] = str[i++];
 		}
 		else
-			result[j++] = str[i++];
+			new_string[j++] = str[i++];
 	}
-	result[j] = '\0';
-	return (result);
+	new_string[j] = '\0';
+	return (new_string);
 }
 
 char	*add_spaces_non_literal(char *str)
 {
 	int		i;
 	int		j;
-	int		in_quotes;
 	char	*new_string;
 
 	i = 0;
 	j = 0;
-	in_quotes = 0;
-	new_string = add_spaces_if_needed(str, in_quotes, i, j);
+	new_string = malloc(sizeof(char) * ((ft_strlen(str) + 1) * 2));
+	if (!new_string)
+		return (NULL);
+	new_string = add_spaces_if_needed(str, i, j, new_string);
 	free(str);
 	return (new_string);
 }


### PR DESCRIPTION
Minishell now correctly separates cat || ls to cat | | ls (which would return syntax error).